### PR TITLE
fix possible StringIndexOutOfBoundsException

### DIFF
--- a/src/org/hsqldb/StatementHandler.java
+++ b/src/org/hsqldb/StatementHandler.java
@@ -111,21 +111,21 @@ public class StatementHandler extends Statement {
         if (conditionStates.contains(sqlState)) {
             return true;
         }
+        if (sqlState.length() >= 2) {
+            String conditionClass = sqlState.substring(0, 2);
 
-        String conditionClass = sqlState.substring(0, 2);
+            if (conditionStates.contains(conditionClass)) {
+                return true;
+            }
 
-        if (conditionStates.contains(conditionClass)) {
-            return true;
+            if (conditionClass.equals("01")) {
+                return conditionGroups.contains(SQL_WARNING);
+            }
+
+            if (conditionClass.equals("02")) {
+                return conditionGroups.contains(SQL_NOT_FOUND);
+            }
         }
-
-        if (conditionClass.equals("01")) {
-            return conditionGroups.contains(SQL_WARNING);
-        }
-
-        if (conditionClass.equals("02")) {
-            return conditionGroups.contains(SQL_NOT_FOUND);
-        }
-
         return conditionGroups.contains(SQL_EXCEPTION);
     }
 


### PR DESCRIPTION
Judge the length of sqlState before using `String conditionClass = sqlState.substring(0, 2);`
otherwise it will throw StringIndexOutOfBoundsException